### PR TITLE
Add contrasting color extension

### DIFF
--- a/app/src/main/java/dev/jorgecastillo/androidcolorx/GeneratedColorsAdapter.kt
+++ b/app/src/main/java/dev/jorgecastillo/androidcolorx/GeneratedColorsAdapter.kt
@@ -24,11 +24,11 @@ class GeneratedColorsAdapter : RecyclerView.Adapter<GeneratedColorsAdapter.ViewH
     override fun getItemCount(): Int = colors.size
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(colors[position], position)
+        holder.bind(colors[position])
     }
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        fun bind(color: Int, position: Int) {
+        fun bind(color: Int) {
             val colorSquare = itemView.findViewById<RoundedCornersColor>(R.id.colorSquare)
             colorSquare.setColor(color)
 

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/ARGBColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/ARGBColor.kt
@@ -104,3 +104,16 @@ fun ARGBColor.analogous(): Pair<ARGBColor, ARGBColor> =
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun ARGBColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun ARGBColor.contrasting(
+    lightColor: ARGBColor = ARGBColor(255, 255, 255, 255),
+    darkColor: ARGBColor = ARGBColor(255, 0, 0, 0)
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/CMYKColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/CMYKColor.kt
@@ -133,3 +133,16 @@ fun CMYKColor.analogous(): Pair<CMYKColor, CMYKColor> =
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun CMYKColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun CMYKColor.contrasting(
+    lightColor: CMYKColor = CMYKColor(0f, 0f, 0f, 0f), // white
+    darkColor: CMYKColor = CMYKColor(0f, 0f, 0f, 1f) // black
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/ColorIntExtensions.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/ColorIntExtensions.kt
@@ -1,5 +1,6 @@
 package dev.jorgecastillo.androidcolorx.library
 
+import android.graphics.Color
 import androidx.annotation.ColorInt
 import androidx.annotation.IntRange
 import androidx.core.graphics.ColorUtils
@@ -19,24 +20,6 @@ import kotlin.math.roundToInt
 @ColorInt
 fun rgbColorInt(red: Float, green: Float, blue: Float): Int {
     return -0x1000000 or
-            ((red * 255.0f + 0.5f).toInt() shl 16) or
-            ((green * 255.0f + 0.5f).toInt() shl 8) or
-            (blue * 255.0f + 0.5f).toInt()
-}
-
-/**
- * Return a color-int from alpha, red, green, blue float components
- * in the range \([0..1]\). If the components are out of range, the
- * returned color is undefined.
- *
- * @param alpha Alpha component \([0..1]\) of the color
- * @param red Red component \([0..1]\) of the color
- * @param green Green component \([0..1]\) of the color
- * @param blue Blue component \([0..1]\) of the color
- */
-@ColorInt
-fun argbColorInt(alpha: Float, red: Float, green: Float, blue: Float): Int {
-    return (alpha * 255.0f + 0.5f).toInt() shl 24 or
             ((red * 255.0f + 0.5f).toInt() shl 16) or
             ((green * 255.0f + 0.5f).toInt() shl 8) or
             (blue * 255.0f + 0.5f).toInt()
@@ -170,10 +153,24 @@ fun rgbToHsl(
     outHsl[1] = constrain(s, 0f, 1f)
     outHsl[2] = constrain(l, 0f, 1f)
 }
+
 /**
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun @receiver:ColorInt Int.isDark(): Boolean = ColorUtils.calculateLuminance(this) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun @receiver:ColorInt Int.contrasting(
+    @ColorInt lightColor: Int = Color.WHITE,
+    @ColorInt darkColor: Int = Color.BLACK
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}
 
 /**
  * @param value amount to lighten in the range 0...1

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HEXColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HEXColor.kt
@@ -123,3 +123,16 @@ fun HEXColor.analogous(): Pair<HEXColor, HEXColor> =
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun HEXColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun HEXColor.contrasting(
+    lightColor: HEXColor = HEXColor("#FFFFFF"),
+    darkColor: HEXColor = HEXColor("#000000")
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLAColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLAColor.kt
@@ -126,3 +126,16 @@ fun HSLAColor.analogous(): Pair<HSLAColor, HSLAColor> =
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun HSLAColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun HSLAColor.contrasting(
+    lightColor: HSLAColor = HSLAColor(0f, 0f, 1f, 1f), // white
+    darkColor: HSLAColor = HSLAColor(0f, 0f, 0f, 1f) // black
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLColor.kt
@@ -113,3 +113,16 @@ fun HSLColor.analogous(): Pair<HSLColor, HSLColor> =
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun HSLColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun HSLColor.contrasting(
+    lightColor: HSLColor = HSLColor(0f, 0f, 1f), // white
+    darkColor: HSLColor = HSLColor(0f, 0f, 0f) // black
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/RGBColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/RGBColor.kt
@@ -103,3 +103,16 @@ fun RGBColor.analogous(): Pair<RGBColor, RGBColor> =
  * Check if a color is dark (convert to XYZ & check Y component)
  */
 fun RGBColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun RGBColor.contrasting(
+    lightColor: RGBColor = RGBColor(255, 255, 255),
+    darkColor: RGBColor = RGBColor(0, 0, 0)
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ARGBColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ARGBColorTests.kt
@@ -134,7 +134,10 @@ class ARGBColorTests {
 
         assertEquals(
             lightColor,
-            color.contrasting(lightColor = lightColor, darkColor = ARGBColor(255,0, 0, 0))
+            color.contrasting(
+                lightColor = lightColor,
+                darkColor = ARGBColor(255, 0, 0, 0)
+            )
         )
     }
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ARGBColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ARGBColorTests.kt
@@ -114,6 +114,42 @@ class ARGBColorTests {
     }
 
     @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = ARGBColor(255, 233, 30, 99)
+
+        assertEquals(ARGBColor(255, 255, 255, 255), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = ARGBColor(255, 251, 234, 248)
+
+        assertEquals(ARGBColor(255, 0, 0, 0), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = ARGBColor(255, 233, 30, 99)
+        val lightColor = ARGBColor(255, 251, 234, 248)
+
+        assertEquals(
+            lightColor,
+            color.contrasting(lightColor = lightColor, darkColor = ARGBColor(255,0, 0, 0))
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = ARGBColor(255, 251, 234, 248)
+        val darkColor = ARGBColor(255, 233, 30, 99)
+
+        assertEquals(
+            darkColor,
+            color.contrasting(lightColor = ARGBColor(255, 255, 255, 255), darkColor = darkColor)
+        )
+    }
+
+    @Test
     fun `triadic colors should be calculated as expected`() {
         val color = ARGBColor(20, 233, 30, 99)
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/CMYKColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/CMYKColorTests.kt
@@ -117,6 +117,48 @@ class CMYKColorTests {
     }
 
     @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = CMYKColor(0f, 0.87f, 0.58f, 0.09f)
+
+        assertEquals(CMYKColor(0f, 0f, 0f, 0f), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = CMYKColor(0.87f, 0.00f, 0.29f, 0.09f)
+
+        assertEquals(CMYKColor(0f, 0f, 0f, 1f), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = CMYKColor(0f, 0.87f, 0.58f, 0.09f)
+        val lightColor = CMYKColor(0.87f, 0.00f, 0.29f, 0.09f)
+
+        assertEquals(
+            lightColor,
+            color.contrasting(
+                lightColor = lightColor,
+                darkColor = CMYKColor(0f, 0f, 0f, 1f)
+            )
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = CMYKColor(0.87f, 0.00f, 0.29f, 0.09f)
+        val darkColor = CMYKColor(0f, 0.87f, 0.58f, 0.09f)
+
+        assertEquals(
+            darkColor,
+            color.contrasting(
+                lightColor = CMYKColor(0f, 0f, 0f, 0f),
+                darkColor = darkColor
+            )
+        )
+    }
+
+    @Test
     fun `triadic colors should be calculated as expected`() {
         val color = CMYKColor(0f, 0.87f, 0.58f, 0.09f)
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ColorIntTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ColorIntTests.kt
@@ -81,7 +81,8 @@ class ColorIntTests {
                 -15203830,
                 -16777216
             ),
-            color.shades())
+            color.shades()
+        )
     }
 
     @Test
@@ -102,7 +103,8 @@ class ColorIntTests {
                 -136977,
                 -1
             ),
-            color.tints())
+            color.tints()
+        )
     }
 
     @Test
@@ -110,6 +112,42 @@ class ColorIntTests {
         val color = Color.parseColor("#e91e63")
 
         assertEquals(-14751324, color.complimentary())
+    }
+
+    @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = Color.parseColor("#e91e63")
+
+        assertEquals(Color.WHITE, color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = Color.parseColor("#d4e7e4")
+
+        assertEquals(Color.BLACK, color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = Color.parseColor("#e91e63")
+        val lightColor = Color.parseColor("#d4e7e4")
+
+        assertEquals(
+            lightColor,
+            color.contrasting(lightColor = lightColor, darkColor = Color.BLACK)
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = Color.parseColor("#d4e7e4")
+        val darkColor = Color.parseColor("#e91e63")
+
+        assertEquals(
+            darkColor,
+            color.contrasting(lightColor = Color.WHITE, darkColor = darkColor)
+        )
     }
 
     @Test

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HEXColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HEXColorTests.kt
@@ -114,6 +114,42 @@ class HEXColorTests {
     }
 
     @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = HEXColor("#e91e63")
+
+        assertEquals(HEXColor("#ffffff"), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = HEXColor("#FF1EE9A4")
+
+        assertEquals(HEXColor("#000000"), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = HEXColor("#e91e63")
+        val lightColor = HEXColor("#FF1EE9A4")
+
+        assertEquals(
+            lightColor,
+            color.contrasting(lightColor = lightColor, darkColor = HEXColor("#000000"))
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = HEXColor("#FF1EE9A4")
+        val darkColor = HEXColor("#e91e63")
+
+        assertEquals(
+            darkColor,
+            color.contrasting(lightColor = HEXColor("#ffffff"), darkColor = darkColor)
+        )
+    }
+
+    @Test
     fun `triadic colors should be calculated as expected`() {
         val color = HEXColor("#e91e63")
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLAColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLAColorTests.kt
@@ -113,6 +113,48 @@ class HSLAColorTests {
     }
 
     @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = HSLAColor(339.7f, 0.82f, 0.52f, 0.2f)
+
+        assertEquals(HSLAColor(0f, 0f, 1f, 1f), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = HSLAColor(159.70f, 0.82f, 0.52f, 0.2f)
+
+        assertEquals(HSLAColor(0f, 0f, 0f, 1f), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = HSLAColor(339.7f, 0.82f, 0.52f, 0.2f)
+        val lightColor = HSLAColor(159.70f, 0.82f, 0.52f, 0.2f)
+
+        assertEquals(
+            lightColor,
+            color.contrasting(
+                lightColor = lightColor,
+                darkColor = HSLAColor(0f, 0f, 0f, 1f)
+            )
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = HSLAColor(159.70f, 0.82f, 0.52f, 0.2f)
+        val darkColor = HSLAColor(339.7f, 0.82f, 0.52f, 0.2f)
+
+        assertEquals(
+            darkColor,
+            color.contrasting(
+                lightColor = HSLAColor(0f, 0f, 1f, 1f),
+                darkColor = darkColor
+            )
+        )
+    }
+
+    @Test
     fun `triadic colors should be calculated as expected`() {
         val color = HSLAColor(339.61f, 0.82f, 0.52f, 0.2f)
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLColorTests.kt
@@ -113,6 +113,48 @@ class HSLColorTests {
     }
 
     @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = HSLColor(339.7f, 0.82f, 0.52f)
+
+        assertEquals(HSLColor(0f, 0f, 1f), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = HSLColor(159.70f, 0.82f, 0.52f)
+
+        assertEquals(HSLColor(0f, 0f, 0f), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = HSLColor(339.7f, 0.82f, 0.52f)
+        val lightColor = HSLColor(159.70f, 0.82f, 0.52f)
+
+        assertEquals(
+            lightColor,
+            color.contrasting(
+                lightColor = lightColor,
+                darkColor = HSLColor(0f, 0f, 0f)
+            )
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = HSLColor(159.70f, 0.82f, 0.52f)
+        val darkColor = HSLColor(339.7f, 0.82f, 0.52f)
+
+        assertEquals(
+            darkColor,
+            color.contrasting(
+                lightColor = HSLColor(0f, 0f, 1f),
+                darkColor = darkColor
+            )
+        )
+    }
+
+    @Test
     fun `triadic colors should be calculated as expected`() {
         val color = HSLColor(339.61f, 0.82f, 0.52f)
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/RGBColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/RGBColorTests.kt
@@ -114,6 +114,42 @@ class RGBColorTests {
     }
 
     @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = RGBColor(233, 30, 99)
+
+        assertEquals(RGBColor(255, 255, 255), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = RGBColor(251, 234, 248)
+
+        assertEquals(RGBColor(0, 0, 0), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = RGBColor(233, 30, 99)
+        val lightColor = RGBColor(251, 234, 248)
+
+        assertEquals(
+            lightColor,
+            color.contrasting(lightColor = lightColor, darkColor = RGBColor(0, 0, 0))
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = RGBColor(251, 234, 248)
+        val darkColor = RGBColor(233, 30, 99)
+
+        assertEquals(
+            darkColor,
+            color.contrasting(lightColor = RGBColor(255, 255, 255), darkColor = darkColor)
+        )
+    }
+
+    @Test
     fun `triadic colors should be calculated as expected`() {
         val color = RGBColor(233, 30, 99)
 


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #5 

### :tophat: What is the goal?

We want to add an extension to calculate a color with proper contrast given another color. The idea is to rely on `isDark()` extension and to get a color that can be used to render icons or text with good contrast on top of colored backgrounds.

### 💻 How is it being implemented?

* Added the extension to all color types available.
* Added tests.

### 📱 How to Test

* Let CI run.