### PR TITLE
Add support for HSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This library provides seamless conversion between the following color types:
 * `HEXColor`
 * `HSLColor`
 * `HSLAColor`
+* `HSVColor`
 * `CMYKColor`
 
 To convert a color type to any of the other types, you can use the extensions provided for it.
@@ -35,6 +36,7 @@ val argb = color.asArgb()
 val hex = color.asHex()
 val hsl = color.asHsl()
 val hsla = color.asHsla()
+val hsv = color.asHsv()
 val cmyk = color.asCmyk()
 
 val colorHsl = HSLColor(hue = 210f, saturation = 0.5f, lightness = 0.5f)
@@ -45,9 +47,12 @@ val argb = colorHsl.asArgb()
 val hex = colorHsl.asHex()
 val cmyk = colorHsl.asCmyk()
 val hsla = colorHsl.asHsla()
+val hsv = colorHsl.asHsv()
 ```
 
 The same extensions **are available for all the mentioned color types**. Note that when converting from a color with an alpha component (i.e: `ARGB` or `HSLA`) to one without it (i.e: `RGB` or `HSL`) it will be a lossy conversion. If it's the other way around, conversions will assume full alpha (255 or 1f).
+
+Also note that conversions from colors that store their components as `Float` (i.e: cmyk, hsl, hsla) to colors that store them as `Int` (i.e: RGBColor, ColorInt) and back will imply precision loss.
 
 ### Shades and tints
 
@@ -65,6 +70,7 @@ val color = Color.parseColor("#e91e63")
 val shades: List<Int> = color.shades()
 val shadesHsl: List<HSLColor> = color.asHsl().shades()
 val shadesHsla: List<HSLAColor> = color.asHsla().shades()
+val shadesHsv: List<HSVColor> = color.asHsv().shades()
 val shadesCmyk: List<CMYKColor> = color.asCmyk().shades()
 val shadesHex: List<HEXColor> = color.asHex().shades()
 val shadesRgb: List<RGBColor> = color.asRgb().shades()
@@ -74,6 +80,7 @@ val shadesArgb: List<ARGBColor> = color.asArgb().shades()
 val tints: List<Int> = color.tints()
 val tintsHsl: List<HSLColor> = color.asHsl().tints()
 val tintsHsla: List<HSLAColor> = color.asHsla().tints()
+val tintsHsv: List<HSVColor> = color.asHsv().tints()
 val tintsCmyk: List<CMYKColor> = color.asCmyk().tints()
 val tintsHex: List<HEXColor> = color.asHex().tints()
 val tintsRgb: List<RGBColor> = color.asRgb().tints()

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/ARGBColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/ARGBColor.kt
@@ -31,6 +31,8 @@ fun ARGBColor.asHsl(): HSLColor = asColorInt().asHsl()
 
 fun ARGBColor.asHsla(): HSLAColor = asColorInt().asHsla()
 
+fun ARGBColor.asHsv(): HSVColor = asColorInt().asHsv()
+
 /**
  * @param value amount to lighten in the range 0...1
  */

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/CMYKColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/CMYKColor.kt
@@ -60,6 +60,8 @@ fun CMYKColor.asHsl(): HSLColor = asColorInt().asHsl()
 fun CMYKColor.asHsla(): HSLAColor =
     asHsl().let { HSLAColor(it.hue, it.saturation, it.lightness, 1f) }
 
+fun CMYKColor.asHsv(): HSVColor = asColorInt().asHsv()
+
 /**
  * @param value amount to lighten in the range 0...1
  */

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HEXColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HEXColor.kt
@@ -50,6 +50,8 @@ fun HEXColor.asHsl(): HSLColor = asColorInt().asHsl()
 
 fun HEXColor.asHsla(): HSLAColor = asColorInt().asHsla()
 
+fun HEXColor.asHsv(): HSVColor = asColorInt().asHsv()
+
 /**
  * @param value amount to lighten in the range 0...1
  */

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLAColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLAColor.kt
@@ -53,6 +53,8 @@ fun HSLAColor.asHex(): HEXColor = asColorInt().asHex()
 
 fun HSLAColor.asHsl(): HSLColor = asColorInt().asHsl()
 
+fun HSLAColor.asHsv(): HSVColor = asColorInt().asHsv()
+
 /**
  * @param value amount to lighten in the range 0...1
  */

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSLColor.kt
@@ -40,6 +40,8 @@ fun HSLColor.asHex(): HEXColor = asColorInt().asHex()
 
 fun HSLColor.asHsla(): HSLAColor = HSLAColor(hue, saturation, lightness, 1f)
 
+fun HSLColor.asHsv(): HSVColor = asColorInt().asHsv()
+
 /**
  * @param value amount to lighten in the range 0...1
  */

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSVColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/HSVColor.kt
@@ -1,0 +1,128 @@
+package dev.jorgecastillo.androidcolorx.library
+
+import android.graphics.Color
+import androidx.annotation.ColorInt
+import androidx.annotation.NonNull
+import androidx.core.graphics.ColorUtils
+
+/**
+ * HSV stands for hue-saturation-value (sometimes also known as HSB, hue-saturation-brightness).
+ *
+ * Hue is a value from 0...360
+ * Saturation is a value from 0...1
+ * Lightness is a value from 0...1
+ */
+data class HSVColor(
+    val hue: Float,
+    val saturation: Float,
+    val value: Float
+)
+
+@NonNull
+fun @receiver:ColorInt Int.asHsv(): HSVColor {
+    val hsvArray = FloatArray(3)
+    Color.colorToHSV(this, hsvArray)
+    return HSVColor(hsvArray[0], hsvArray[1], hsvArray[2])
+}
+
+@ColorInt
+fun HSVColor.asColorInt(): Int = Color.HSVToColor(floatArrayOf(hue, saturation, value))
+
+fun HSVColor.asRgb(): RGBColor = asColorInt().asRgb()
+
+fun HSVColor.asArgb(): ARGBColor = asRgb().asArgb()
+
+fun HSVColor.asCmyk(): CMYKColor = asColorInt().asCmyk()
+
+fun HSVColor.asHex(): HEXColor = asColorInt().asHex()
+
+fun HSVColor.asHsl(): HSLColor = asColorInt().asHsl()
+
+fun HSVColor.asHsla(): HSLAColor = asColorInt().asHsla()
+
+/**
+ * @param value amount to lighten in the range 0...1
+ */
+fun HSVColor.lighten(value: Float): HSVColor = this.asColorInt().lighten(value).asHsv()
+
+/**
+ * @param value amount to lighten in the range 0...100
+ */
+fun HSVColor.lighten(value: Int): HSVColor = this.asColorInt().lighten(value).asHsv()
+
+/**
+ * @param value amount to darken in the range 0...1
+ */
+fun HSVColor.darken(value: Float): HSVColor = this.asColorInt().darken(value).asHsv()
+
+/**
+ * @param value amount to darken in the range 0...100
+ */
+fun HSVColor.darken(value: Int): HSVColor = this.asColorInt().darken(value).asHsv()
+
+/**
+ * @return a list of shades for the given color like the ones in https://www.color-hex.com/color/e91e63.
+ * Each one of the colors is a HSLColor.
+ */
+fun HSVColor.shades(): List<HSVColor> = asColorInt().shades().map { it.asHsv() }
+
+/**
+ * @return a list of tints for the given color like the ones in https://www.color-hex.com/color/e91e63.
+ * Each one of the colors is a HSLColor.
+ */
+fun HSVColor.tints(): List<HSVColor> = asColorInt().tints().map { it.asHsv() }
+
+/**
+ * The Hue is the colour's position on the colour wheel, expressed in degrees from 0° to 359°, representing the 360° of
+ * the wheel; 0° being red, 180° being red's opposite colour cyan, and so on. The complimentary color stands for the
+ * color in the opposite side of the circle, so it's (hue + 180) % 360.
+ */
+fun HSVColor.complimentary(): HSVColor = asColorInt().complimentary().asHsv()
+
+/**
+ * The Hue is the colour's position on the colour wheel, expressed in degrees from 0° to 359°, representing the 360° of
+ * the wheel; 0° being red, 180° being red's opposite colour cyan, and so on. The triadic colors stand for 3 colors that
+ * compose a perfect triangle (equal sides) over the circle, so they are equally far from each other.
+ *
+ * Triadic colors for h0 would be (hue + 120) % 360 and (hue + 240) % 360.
+ */
+fun HSVColor.triadic(): Pair<HSVColor, HSVColor> =
+    asColorInt().triadic().let { Pair(it.first.asHsv(), it.second.asHsv()) }
+
+/**
+ * The Hue is the colour's position on the colour wheel, expressed in degrees from 0° to 359°, representing the 360° of
+ * the wheel; 0° being red, 180° being red's opposite colour cyan, and so on. The tetradic colors stand for 4 colors
+ * that compose a perfect square (equal sides) over the circle, so they are equally far from each other.
+ *
+ * Tetradic colors for h0 would be (hue + 90) % 360, (hue + 180) % 360 and (hue + 270) % 360.
+ */
+fun HSVColor.tetradic(): Triple<HSVColor, HSVColor, HSVColor> =
+    asColorInt().tetradic().let { Triple(it.first.asHsv(), it.second.asHsv(), it.third.asHsv()) }
+
+/**
+ * The Hue is the colour's position on the colour wheel, expressed in degrees from 0° to 359°, representing the 360° of
+ * the wheel; 0° being red, 180° being red's opposite colour cyan, and so on. The analogous colors stand for 3 colors
+ * that are together in the circle, separated by 30 degrees each.
+ *
+ * Analogous colors for h0 would be (hue + 30) % 360 & (hue - 30) % 360.
+ */
+fun HSVColor.analogous(): Pair<HSVColor, HSVColor> =
+    asColorInt().analogous().let { Pair(it.first.asHsv(), it.second.asHsv()) }
+
+/**
+ * Check if a color is dark (convert to XYZ & check Y component)
+ */
+fun HSVColor.isDark(): Boolean = ColorUtils.calculateLuminance(this.asColorInt()) < 0.5
+
+/**
+ * Returns a color that contrasts nicely with the one given (receiver). Fallbacks to white and
+ * black, but optional light and dark colors can be passed.
+ */
+fun HSVColor.contrasting(
+    lightColor: HSVColor = HSVColor(0f, 0f, 1f), // white
+    darkColor: HSVColor = HSVColor(0f, 0f, 0f) // black
+) = if (isDark()) {
+    lightColor
+} else {
+    darkColor
+}

--- a/library/src/main/java/dev/jorgecastillo/androidcolorx/library/RGBColor.kt
+++ b/library/src/main/java/dev/jorgecastillo/androidcolorx/library/RGBColor.kt
@@ -30,6 +30,8 @@ fun RGBColor.asHsl(): HSLColor = asColorInt().asHsl()
 
 fun RGBColor.asHsla(): HSLAColor = asColorInt().asHsla()
 
+fun RGBColor.asHsv(): HSVColor = asColorInt().asHsv()
+
 /**
  * @param value amount to lighten in the range 0...1
  */

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ARGBColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ARGBColorTests.kt
@@ -227,4 +227,11 @@ class ARGBColorTests {
 
         assertEquals(color.copy(alpha = 255), color.asCmyk().asArgb())
     }
+
+    @Test
+    fun `converts to HSV and back just loses information about alpha`() {
+        val color = ARGBColor(20, 233, 30, 99)
+
+        assertEquals(color.copy(alpha = 255), color.asHsv().asArgb())
+    }
 }

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/AssertExtensions.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/AssertExtensions.kt
@@ -22,6 +22,11 @@ infix fun <T> T.eqWithUnderstandablePrecisionLoss(other: T): Unit = when (this) 
         assertEquals(lightness.round(2), (other as HSLAColor).lightness.round(2))
         assertEquals(alpha.round(2), (other as HSLAColor).alpha.round(2))
     }
+    is HSVColor -> {
+        assertEquals(hue.round(2), (other as HSVColor).hue.round(2))
+        assertEquals(saturation.round(2), (other as HSVColor).saturation.round(2))
+        assertEquals(value.round(2), (other as HSVColor).value.round(2))
+    }
     else -> fail()
 }
 

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/CMYKColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/CMYKColorTests.kt
@@ -230,4 +230,11 @@ class CMYKColorTests {
 
         color eqWithUnderstandablePrecisionLoss color.asHex().asCmyk()
     }
+
+    @Test
+    fun `converts to HSV and back is idempotent`() {
+        val color = CMYKColor(0f, 0.87f, 0.58f, 0.09f)
+
+        color eqWithUnderstandablePrecisionLoss color.asHsv().asCmyk()
+    }
 }

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ColorIntTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/ColorIntTests.kt
@@ -228,4 +228,11 @@ class ColorIntTests {
 
         assertEquals(color, color.asCmyk().asColorInt())
     }
+
+    @Test
+    fun `converts to HSV and back is idempotent`() {
+        val color = Color.parseColor("#e91e63")
+
+        assertEquals(color, color.asHsv().asColorInt())
+    }
 }

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HEXColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HEXColorTests.kt
@@ -224,4 +224,11 @@ class HEXColorTests {
 
         assertEquals(color.copy(hex = "#FF${color.hex.drop(3)}"), color.asCmyk().asHex())
     }
+
+    @Test
+    fun `converts to HSV and back just loses information about alpha`() {
+        val color = HEXColor("#55e91e63")
+
+        assertEquals(color.copy(hex = "#FF${color.hex.drop(3)}"), color.asHsv().asHex())
+    }
 }

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLAColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLAColorTests.kt
@@ -226,4 +226,11 @@ class HSLAColorTests {
 
         color.copy(alpha = 1f) eqWithUnderstandablePrecisionLoss color.asCmyk().asHsla()
     }
+
+    @Test
+    fun `converts to HSV and back just loses information about alpha`() {
+        val color = HSLAColor(339.7f, 0.82f, 0.52f, 0.2f)
+
+        color.copy(alpha = 1f) eqWithUnderstandablePrecisionLoss color.asHsv().asHsla()
+    }
 }

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSLColorTests.kt
@@ -250,4 +250,11 @@ class HSLColorTests {
 
         color eqWithUnderstandablePrecisionLoss color.asCmyk().asHsl()
     }
+
+    @Test
+    fun `converts to HSV and back is idempotent`() {
+        val color = HSLColor(339.7f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asHsv().asHsl()
+    }
 }

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSVColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/HSVColorTests.kt
@@ -1,0 +1,267 @@
+package dev.jorgecastillo.androidcolorx.library
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+@RunWith(AndroidJUnit4::class)
+class HSVColorTests {
+
+    @Test
+    fun `is dark should return true for #e91e63`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        assertTrue(color.isDark())
+    }
+
+    @Test
+    fun `is dark should return false for #1ee9a4`() {
+        val color = HSVColor(290f, 0.17f, 1f)
+
+        assertFalse(color.isDark())
+    }
+
+    @Test
+    fun `lighten integer should enlighten the color`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        HSVColor(339.43f, 0.81f, 0.85f) eqWithUnderstandablePrecisionLoss
+                color.lighten(20)
+    }
+
+    @Test
+    fun `lighten float should enlighten the color`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        HSVColor(339.43f, 0.81f, 0.85f) eqWithUnderstandablePrecisionLoss
+                color.lighten(0.2f)
+    }
+
+    @Test
+    fun `lighten integer should be equivalent to lighten float`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        assertEquals(color.lighten(20), color.lighten(0.2f))
+    }
+
+    @Test
+    fun `darken integer should darken the color`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        HSVColor(340f, 0.83f, 0.18f) eqWithUnderstandablePrecisionLoss
+                color.darken(20)
+    }
+
+    @Test
+    fun `darken float should darken the color`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        HSVColor(340f, 0.83f, 0.18f) eqWithUnderstandablePrecisionLoss
+                color.darken(0.2f)
+    }
+
+    @Test
+    fun `darken integer should be equivalent to dark float`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        assertEquals(color.darken(20), color.darken(0.2f))
+    }
+
+    @Test
+    fun `shades should be properly calculated`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        listOf(
+            HSVColor(339.63f, 0.82f, 0.52f),
+            HSVColor(339.8f, 0.82f, 0.47f),
+            HSVColor(339.31f, 0.82f, 0.42f),
+            HSVColor(339.47f, 0.82f, 0.36f),
+            HSVColor(339.09f, 0.82f, 0.31f),
+            HSVColor(339.27f, 0.82f, 0.26f),
+            HSVColor(340.47f, 0.81f, 0.21f),
+            HSVColor(340f, 0.82f, 0.16f),
+            HSVColor(340.91f, 0.81f, 0.11f),
+            HSVColor(338.18f, 0.85f, 0.05f),
+            HSVColor(0.00f, 0.00f, 0.00f)
+        ) eqWithUnderstandablePrecisionLoss color.shades()
+    }
+
+    @Test
+    fun `tints should be properly calculated`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        listOf(
+            HSVColor(339.63f, 0.82f, 0.52f),
+            HSVColor(339.4f, 0.82f, 0.64f),
+            HSVColor(339.87f, 0.82f, 0.76f),
+            HSVColor(339.65f, 0.79f, 0.85f),
+            HSVColor(340.0f, 0.66f, 0.87f),
+            HSVColor(339.51f, 0.54f, 0.89f),
+            HSVColor(339.18f, 0.42f, 0.91f),
+            HSVColor(339.73f, 0.31f, 0.94f),
+            HSVColor(339.18f, 0.2f, 0.96f),
+            HSVColor(340.8f, 0.1f, 0.98f),
+            HSVColor(0.00f, 0.00f, 1.00f)
+        ) eqWithUnderstandablePrecisionLoss color.tints()
+    }
+
+    @Test
+    fun `complimentary colors should be calculated as expected`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        HSVColor(159.63f, 0.82f, 0.52f) eqWithUnderstandablePrecisionLoss
+                color.complimentary()
+    }
+
+    @Test
+    fun `returns white as contrasting color for dark colors`() {
+        val color = HSVColor(339.7f, 0.82f, 0.52f)
+
+        assertEquals(HSVColor(0f, 0f, 1f), color.contrasting())
+    }
+
+    @Test
+    fun `returns black as contrasting color for light colors`() {
+        val color = HSVColor(290f, 0.17f, 1f)
+
+        assertEquals(HSVColor(0f, 0f, 0f), color.contrasting())
+    }
+
+    @Test
+    fun `returns passed light color as contrasting color for dark colors`() {
+        val color = HSVColor(339.7f, 0.82f, 0.52f)
+        val lightColor = HSVColor(290f, 0.17f, 1f)
+
+        assertEquals(
+            lightColor,
+            color.contrasting(
+                lightColor = lightColor,
+                darkColor = HSVColor(0f, 0f, 0f)
+            )
+        )
+    }
+
+    @Test
+    fun `returns passed dark color as contrasting color for light colors`() {
+        val color = HSVColor(290f, 0.17f, 1f)
+        val darkColor = HSVColor(339.7f, 0.82f, 0.52f)
+
+        assertEquals(
+            darkColor,
+            color.contrasting(
+                lightColor = HSVColor(0f, 0f, 1f),
+                darkColor = darkColor
+            )
+        )
+    }
+
+    @Test
+    fun `triadic colors should be calculated as expected`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        Pair(
+            HSVColor(99.63f, 0.82f, 0.52f),
+            HSVColor(219.63f, 0.82f, 0.52f)
+        ) eqWithUnderstandablePrecisionLoss Pair(
+            color.triadic().first,
+            color.triadic().second
+        )
+    }
+
+    @Test
+    fun `tetradic colors should be calculated as expected`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        Triple(
+            HSVColor(69.36f, 0.82f, 0.52f),
+            HSVColor(159.63f, 0.82f, 0.52f),
+            HSVColor(249.91f, 0.82f, 0.52f)
+        ) eqWithUnderstandablePrecisionLoss Triple(
+            color.tetradic().first,
+            color.tetradic().second,
+            color.tetradic().third
+        )
+    }
+
+    @Test
+    fun `analogous colors should be calculated as expected`() {
+        val color = HSVColor(339.61f, 0.82f, 0.52f)
+
+        Pair(
+            HSVColor(9.36f, 0.82f, 0.52f),
+            HSVColor(309.91f, 0.82f, 0.52f)
+        ) eqWithUnderstandablePrecisionLoss Pair(
+            color.analogous().first,
+            color.analogous().second
+        )
+    }
+
+    @Test
+    fun `converts to ColorInt and back is idempotent with understandable precision loss`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asColorInt().asHsv()
+    }
+
+    @Test
+    fun `converts to RGB and back is idempotent with understandable precision loss`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asRgb().asHsv()
+    }
+
+    @Test
+    fun `converts to ARGB and back is idempotent with understandable precision loss`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asArgb().asHsv()
+    }
+
+    @Test
+    fun `converts to ARGB assumes 255 alpha`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        assertEquals(255, color.asArgb().alpha)
+    }
+
+    @Test
+    fun `converts to HEX and back is idempotent`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asHex().asHsv()
+    }
+
+    @Test
+    fun `converts to HSL and back is idempotent`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asHsl().asHsv()
+    }
+
+    @Test
+    fun `converts to HSLA and back is idempotent`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asHsla().asHsv()
+    }
+
+    @Test
+    fun `converts to HSLA assumes 1f alpha`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        assertEquals(1f, color.asHsla().alpha)
+    }
+
+    @Test
+    fun `converts to CMYK and back is idempotent`() {
+        val color = HSVColor(339.63f, 0.82f, 0.52f)
+
+        color eqWithUnderstandablePrecisionLoss color.asCmyk().asHsv()
+    }
+}

--- a/library/src/test/java/dev/jorgecastillo/androidcolorx/library/RGBColorTests.kt
+++ b/library/src/test/java/dev/jorgecastillo/androidcolorx/library/RGBColorTests.kt
@@ -227,4 +227,11 @@ class RGBColorTests {
 
         assertEquals(color, color.asCmyk().asRgb())
     }
+
+    @Test
+    fun `converts to HSV and back is idempotent`() {
+        val color = RGBColor(233, 30, 99)
+
+        assertEquals(color, color.asHsv().asRgb())
+    }
 }


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #1 

### :tophat: What is the goal?

HSV is as used as HSL so it deserves to be supported. The goal is to provide all existent extensions and conversions in the library support for HSV.

### 💻 How is it being implemented?

* Added `HSVColor`
* Added all extensions required to it.
* Added all conversions required to it.
* Added all conversions from other colors to `HSVColor`.
* Added tests for everything.

### 📱 How to Test

* Let CI run.